### PR TITLE
Match the latest spec

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,6 @@ declare namespace srcset {
 	interface SrcSetDefinition {
 		url: string;
 		width?: number;
-		height?: number;
 		density?: number;
 	}
 }

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ function deepUnique(array) {
 
 exports.parse = string => {
 	return deepUnique(
-		string.split(',').map(part => {
+		string.split(/,\s+/).map(part => {
 			const result = {};
 
 			part

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const integerRegex = /^\d+$/;
+const integerRegex = /^-?\d+$/;
 
 function deepUnique(array) {
 	return array.sort().filter((element, index) => {
@@ -28,8 +28,16 @@ exports.parse = string => {
 					const floatValue = parseFloat(value);
 
 					if (postfix === 'w' && integerRegex.test(value)) {
+						if (integerValue <= 0) {
+							throw new Error('Width descriptor must be greater than zero');
+						}
+
 						result.width = integerValue;
 					} else if (postfix === 'x' && !Number.isNaN(floatValue)) {
+						if (floatValue <= 0) {
+							throw new Error('Pixel density descriptor must be greater than zero');
+						}
+
 						result.density = floatValue;
 					} else {
 						throw new Error(`Invalid srcset descriptor: ${element}`);

--- a/index.js
+++ b/index.js
@@ -29,8 +29,6 @@ exports.parse = string => {
 
 					if (postfix === 'w' && integerRegex.test(value)) {
 						result.width = integerValue;
-					} else if (postfix === 'h' && integerRegex.test(value)) {
-						result.height = integerValue;
 					} else if (postfix === 'x' && !Number.isNaN(floatValue)) {
 						result.density = floatValue;
 					} else {
@@ -54,10 +52,6 @@ exports.stringify = array => {
 
 			if (element.width) {
 				result.push(`${element.width}w`);
-			}
-
-			if (element.height) {
-				result.push(`${element.height}h`);
 			}
 
 			if (element.density) {

--- a/index.js
+++ b/index.js
@@ -34,6 +34,10 @@ exports.parse = string => {
 					} else {
 						throw new Error(`Invalid srcset descriptor: ${element}`);
 					}
+
+					if (result.width && result.density) {
+						throw new Error('Image candidate string cannot have both width descriptor and pixel density descriptor');
+					}
 				});
 
 			return result;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -6,7 +6,6 @@ expectType<srcset.SrcSetDefinition[]>(parsed);
 
 parsed.push({url: 'banner-phone-HD.jpg'});
 parsed.push({url: 'banner-phone-HD.jpg', width: 100});
-parsed.push({url: 'banner-phone-HD.jpg', height: 100});
 parsed.push({url: 'banner-phone-HD.jpg', density: 2});
 expectError(parsed.push({}));
 

--- a/readme.md
+++ b/readme.md
@@ -60,11 +60,11 @@ banner-HD.jpg 2x, banner-phone.jpg 100w, banner-phone-HD.jpg 100w 2x
 
 ### .parse()
 
-Accepts a srcset string and returns an array of objects with the possible properties: `url` (always), `width`, `height`, `density`.
+Accepts a srcset string and returns an array of objects with the possible properties: `url` (always), `width`, `density`.
 
 ### .stringify()
 
-Accepts an array of objects with the possible properties: `url` (required), `width`, `height`, `density` and returns a srcset string.
+Accepts an array of objects with the possible properties: `url` (required), `width`, `density` and returns a srcset string.
 
 
 ---

--- a/test.js
+++ b/test.js
@@ -2,11 +2,12 @@ import test from 'ava';
 import srcset from '.';
 
 test('.parse() should parse srcset', t => {
-	const fixture = '  banner-HD.jpeg 2x,   banner-HD.jpeg 2x,  banner-HD.jpeg 2x,    banner-phone.jpeg   100w     ';
+	const fixture = '  banner-HD.jpeg 2x,   banner-HD.jpeg 2x,  banner-HD.jpeg 2x,    banner-phone.jpeg   100w, http://site.com/image.jpg?foo=bar,lorem 1x     ';
 
 	t.deepEqual(srcset.parse(fixture), [
 		{url: 'banner-HD.jpeg', density: 2},
-		{url: 'banner-phone.jpeg', width: 100}
+		{url: 'banner-phone.jpeg', width: 100},
+		{url: 'http://site.com/image.jpg?foo=bar,lorem', density: 1}
 	]);
 });
 

--- a/test.js
+++ b/test.js
@@ -2,25 +2,29 @@ import test from 'ava';
 import srcset from '.';
 
 test('.parse() should parse srcset', t => {
-	const fixture = '  banner-HD.jpeg 2x,   banner-HD.jpeg 2x,  banner-HD.jpeg 2x,    banner-phone.jpeg   100w,   banner-phone-HD.jpeg 100w 2x  ';
+	const fixture = '  banner-HD.jpeg 2x,   banner-HD.jpeg 2x,  banner-HD.jpeg 2x,    banner-phone.jpeg   100w     ';
 
 	t.deepEqual(srcset.parse(fixture), [
 		{url: 'banner-HD.jpeg', density: 2},
-		{url: 'banner-phone.jpeg', width: 100},
-		{url: 'banner-phone-HD.jpeg', width: 100, density: 2}
+		{url: 'banner-phone.jpeg', width: 100}
 	]);
+});
+
+test('.parse() should not parse srcset', t => {
+	const fixture = 'banner-phone-HD.jpeg 100w 2x';
+
+	t.throws(() => srcset.parse(fixture));
 });
 
 test('.stringify() should stringify srcset', t => {
 	const fixture = [
 		{url: 'banner-HD.jpeg', density: 2},
 		{url: 'banner-HD.jpeg', density: 2},
-		{url: 'banner-phone.jpeg', width: 100},
-		{url: 'banner-phone-HD.jpeg', width: 100, density: 2}
+		{url: 'banner-phone.jpeg', width: 100}
 	];
 
 	t.deepEqual(
 		srcset.stringify(fixture),
-		'banner-HD.jpeg 2x, banner-phone.jpeg 100w, banner-phone-HD.jpeg 100w 2x'
+		'banner-HD.jpeg 2x, banner-phone.jpeg 100w'
 	);
 });

--- a/test.js
+++ b/test.js
@@ -12,9 +12,9 @@ test('.parse() should parse srcset', t => {
 });
 
 test('.parse() should not parse srcset', t => {
-	const fixture = 'banner-phone-HD.jpeg 100w 2x';
-
-	t.throws(() => srcset.parse(fixture));
+	t.throws(() => srcset.parse('banner-phone-HD.jpeg 100w 2x'));
+	t.throws(() => srcset.parse('banner-phone-HD.jpeg -100w'));
+	t.throws(() => srcset.parse('banner-phone-HD.jpeg -2x'));
 });
 
 test('.stringify() should stringify srcset', t => {


### PR DESCRIPTION
Fixes #1:

- Remove h descriptor
- Image candidate string cannot have both width descriptor and pixel density descriptor
- Support URLs with commas
- Descriptor values must be greater than zero
