### PR TITLE
Fix parsing of srcset without whitespaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,20 +1,20 @@
 'use strict';
 
 /**
- * This regex represents a loose rule of an "image candidate string":
- * @see https://html.spec.whatwg.org/multipage/images.html#srcset-attribute
- *
- * An "image candidate string" roughly consists of the following:
- * 1. 0 or more whitespace.
- * 2. A non-empty url that does not start or end with ",".
- * 3. 0 or more whitespace.
- * 4. An optional "descriptor" that starts with a whitespace.
- * 5. 0 or more whitespace.
- * 6. Each image candidate string is separated by a ",".
- *
- * We intentionally implements a loose rule here so that we can perform
- * more aggressive error handling and reporting in the code below.
- */
+This regex represents a loose rule of an “image candidate string”.
+
+@see https://html.spec.whatwg.org/multipage/images.html#srcset-attribute
+
+An “image candidate string” roughly consists of the following:
+1. Zero or more whitespace characters.
+2. A non-empty URL that does not start or end with `,`.
+3. Zero or more whitespace characters.
+4. An optional “descriptor” that starts with a whitespace character.
+5. Zero or more whitespace characters.
+6. Each image candidate string is separated by a `,`.
+
+We intentionally implement a loose rule here so that we can perform more aggressive error handling and reporting in the below code.
+*/
 const imageCandidateRegex = /\s*([^,]\S*[^,](?:\s+[^,]+)?)\s*(?:,|$)/;
 
 function deepUnique(array) {

--- a/test.js
+++ b/test.js
@@ -53,7 +53,7 @@ test('.parse() should not parse invalid srcset', t => {
 	});
 });
 
-test('.parse() should parse srcset separated without white spaces', t => {
+test('.parse() should parse srcset separated without whitespaces', t => {
 	const fixture = 'banner-HD.jpeg 2x,banner-HD.jpeg 2x,banner-HD.jpeg 2x,banner-phone.jpeg 100w,http://site.com/image.jpg?foo=100w,lorem 1x';
 
 	t.deepEqual(srcset.parse(fixture), [

--- a/test.js
+++ b/test.js
@@ -2,12 +2,13 @@ import test from 'ava';
 import srcset from '.';
 
 test('.parse() should parse srcset', t => {
-	const fixture = '  banner-HD.jpeg 2x,   banner-HD.jpeg 2x,  banner-HD.jpeg 2x,    banner-phone.jpeg   100w, http://site.com/image.jpg?foo=bar,lorem 1x     ';
+	const fixture = '  banner-HD.jpeg 2x,   banner-HD.jpeg 2x,  banner-HD.jpeg 2x,    banner-phone.jpeg   100w, http://site.com/image.jpg?foo=bar,lorem 3x ,banner.jpeg    ';
 
 	t.deepEqual(srcset.parse(fixture), [
 		{url: 'banner-HD.jpeg', density: 2},
 		{url: 'banner-phone.jpeg', width: 100},
-		{url: 'http://site.com/image.jpg?foo=bar,lorem', density: 1}
+		{url: 'http://site.com/image.jpg?foo=bar,lorem', density: 3},
+		{url: 'banner.jpeg', density: 1}
 	]);
 });
 
@@ -42,6 +43,24 @@ test('.parse() should not parse invalid srcset', t => {
 	t.throws(() => {
 		srcset.parse('banner-phone-HD.jpeg -2x');
 	});
+
+	t.throws(() => {
+		srcset.parse('banner-phone-HD.jpeg 100.5w');
+	});
+
+	t.throws(() => {
+		srcset.parse('banner-phone-HD.jpeg xxx');
+	});
+});
+
+test('.parse() should parse srcset separated without white spaces', t => {
+	const fixture = 'banner-HD.jpeg 2x,banner-HD.jpeg 2x,banner-HD.jpeg 2x,banner-phone.jpeg 100w,http://site.com/image.jpg?foo=100w,lorem 1x';
+
+	t.deepEqual(srcset.parse(fixture), [
+		{url: 'banner-HD.jpeg', density: 2},
+		{url: 'banner-phone.jpeg', width: 100},
+		{url: 'http://site.com/image.jpg?foo=100w,lorem', density: 1}
+	]);
 });
 
 test('.stringify() should stringify srcset', t => {


### PR DESCRIPTION
srcset without whitespaces like `banner-HD.jpeg 2x,banner-HD.jpeg 2x,banner-HD.jpeg 2x,banner-phone.jpeg 100w,http://site.com/image.jpg?foo=100w,lorem 1x` cannot be parsed. I rewrote the split logic and refactor the code to match more closely to the [spec](https://html.spec.whatwg.org/multipage/images.html#srcset-attribute). Below are some added rules:

- The width descriptor must not be a float number.
- The value of the descriptor must be a valid number.
- An image candidate string with no descriptors is equivalent to an image candidate string with a `1x` descriptor.

Also added some tests.