### PR TITLE
Update examples to not combine density and width

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ How an image with `srcset` might look like:
 ```html
 <img alt="The Breakfast Combo"
      src="banner.jpg"
-     srcset="banner-HD.jpg 2x, banner-phone.jpg 100w, banner-phone-HD.jpg 100w 2x">
+     srcset="banner-HD.jpg 2x, banner-phone.jpg 100w">
 ```
 
 Then have some fun with it:
@@ -41,15 +41,14 @@ console.log(parsed);
 */
 
 parsed.push({
-	url: 'banner-phone-HD.jpg',
-	width: 100,
-	density: 2
+	url: 'banner-super-HD.jpg',
+	density: 3
 });
 
 const stringified = srcset.stringify(parsed);
 console.log(stringified);
 /*
-banner-HD.jpg 2x, banner-phone.jpg 100w, banner-phone-HD.jpg 100w 2x
+banner-HD.jpg 2x, banner-phone.jpg 100w, banner-super-HD.jpg 3x
 */
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -15,9 +15,11 @@ $ npm install srcset
 How an image with `srcset` might look like:
 
 ```html
-<img alt="The Breakfast Combo"
-     src="banner.jpg"
-     srcset="banner-HD.jpg 2x, banner-phone.jpg 100w">
+<img
+	alt="The Breakfast Combo"
+	src="banner.jpg"
+	srcset="banner-HD.jpg 2x, banner-phone.jpg 100w"
+>
 ```
 
 Then have some fun with it:


### PR DESCRIPTION
Hey, thanks for making this library!

PR #6 updated the codebase to not allow `density` and `width` to be combined when parsing. (Although, amusingly, it _does_ still allow it when stringifying - kind of the opposite of the robustness principle.)

This updates the readme to match so that the examples are correct and parse-able.

On a related note, would you be interested in another PR to make stringifying more strict? Also, what about a not-strict mode that does it's best and doesn't throw errors? (It would be handy for my use-case. For the moment I'm just wrapping this in a try/catch and using the original value if it throws.)