### PR TITLE
Make strict mode optional (but enabled by default) for both .parse() and .stringify()

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,8 +7,9 @@ declare namespace srcset {
 
 	interface SrcSetOptions {
 		/**
-		 * Enable or disable strict mode.
-		 * Defaults to true
+		 * When strict mode is enabled, errors will be thrown on invalid input.
+		 * When disabled, a best effort will be made to handle invalid input and no errors will be thrown. The output may be invalid.
+		 * @default true
 		 */
 		strict?: boolean;
 	}

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,7 +11,7 @@ declare namespace srcset {
 
 		When disabled, a best effort will be made to handle invalid input and no errors will be thrown. The output may be invalid.
 
-		@default true
+		@default false
 		*/
 		strict?: boolean;
 	}

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,7 +19,12 @@ declare const srcset: {
 	/**
 	Parse the HTML `<img>` [srcset](http://mobile.smashingmagazine.com/2013/08/21/webkit-implements-srcset-and-why-its-a-good-thing/) attribute.
 
+	Accepts a srcset string and returns an array of objects with the possible properties: `url` (always), `width`, `density`, and `height`.
+
 	@param srcset - A srcset string.
+
+	@param [options]
+	@param [options.strict=true] - Enable or disable validation of the srcset string. When enabled, an invalid srcset string will cause an error to be thrown. When disabled, a best effort will be made to parse the string, potentially resulting in invalid or nonsensical output.
 
 	@example
 	```
@@ -41,7 +46,12 @@ declare const srcset: {
 	parse: (srcset: string, options?: srcset.SrcSetOptions) => srcset.SrcSetDefinition[];
 
 	/**
-	Stringify `SrcSetDefinition`s.
+	Stringify `SrcSetDefinition`s. Accepts an array of `SrcSetDefinition` objects and returns a srcset string.
+
+	@param SrcSetDefinitions - An array of `SrcSetDefinition` objects. Each object should have a `url` field and may have either `width` or `density`. When `options.strict` is set to false, a `height` field is also accepted, and multiple descriptors (`width`, `height`, and`density`) are accepted.
+
+	@param [options]
+	@param [options.strict=true] - Enable or disable validation of the SrcSetDefinitions. When true, invalid input will cause an error to be thrown. When false, a best effort will be made to stringify invalid input, likely resulting in invalid srcset value.
 
 	@returns A srcset string.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,6 +10,10 @@ declare namespace srcset {
 	}
 
 	interface SrcSetOptions {
+		/**
+		 * Enable or disable strict mode. 
+		 * Defaults to true
+		 */
 		strict?: boolean;
 	}
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,16 +2,12 @@ declare namespace srcset {
 	interface SrcSetDefinition {
 		url: string;
 		width?: number;
-		/**
-		 * @deprecated height is no longer allowed in the srcset specification
-		 */
-		height?: number;
 		density?: number;
 	}
 
 	interface SrcSetOptions {
 		/**
-		 * Enable or disable strict mode. 
+		 * Enable or disable strict mode.
 		 * Defaults to true
 		 */
 		strict?: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -56,16 +56,11 @@ declare const srcset: {
 		{
 			url: 'banner-phone.jpg',
 			width: 100
-		},
-		{
-			url: 'banner-phone-HD.jpg',
-			width: 100,
-			density: 2
 		}
 	]);
 
 	console.log(stringified);
-	// banner-HD.jpg 2x, banner-phone.jpg 100w, banner-phone-HD.jpg 100w 2x
+	// banner-HD.jpg 2x, banner-phone.jpg 100w
 	```
 	*/
 	stringify: (srcSetDefinitions: srcset.SrcSetDefinition[], options?: srcset.SrcSetOptions) => string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,10 +7,12 @@ declare namespace srcset {
 
 	interface SrcSetOptions {
 		/**
-		 * When strict mode is enabled, errors will be thrown on invalid input.
-		 * When disabled, a best effort will be made to handle invalid input and no errors will be thrown. The output may be invalid.
-		 * @default true
-		 */
+		When strict mode is enabled, errors will be thrown on invalid input.
+
+		When disabled, a best effort will be made to handle invalid input and no errors will be thrown. The output may be invalid.
+
+		@default true
+		*/
 		strict?: boolean;
 	}
 }
@@ -22,9 +24,6 @@ declare const srcset: {
 	Accepts a srcset string and returns an array of objects with the possible properties: `url` (always), `width`, `density`, and `height`.
 
 	@param srcset - A srcset string.
-
-	@param [options]
-	@param [options.strict=true] - Enable or disable validation of the srcset string. When enabled, an invalid srcset string will cause an error to be thrown. When disabled, a best effort will be made to parse the string, potentially resulting in invalid or nonsensical output.
 
 	@example
 	```
@@ -49,9 +48,6 @@ declare const srcset: {
 	Stringify `SrcSetDefinition`s. Accepts an array of `SrcSetDefinition` objects and returns a srcset string.
 
 	@param SrcSetDefinitions - An array of `SrcSetDefinition` objects. Each object should have a `url` field and may have either `width` or `density`. When `options.strict` is set to false, a `height` field is also accepted, and multiple descriptors (`width`, `height`, and`density`) are accepted.
-
-	@param [options]
-	@param [options.strict=true] - Enable or disable validation of the SrcSetDefinitions. When true, invalid input will cause an error to be thrown. When false, a best effort will be made to stringify invalid input, likely resulting in invalid srcset value.
 
 	@returns A srcset string.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,15 @@ declare namespace srcset {
 	interface SrcSetDefinition {
 		url: string;
 		width?: number;
+		/**
+		 * @deprecated height is no longer allowed in the srcset specification
+		 */
+		height?: number;
 		density?: number;
+	}
+
+	interface SrcSetOptions {
+		strict?: boolean;
 	}
 }
 
@@ -29,7 +37,7 @@ declare const srcset: {
 	// ]
 	```
 	*/
-	parse: (srcset: string) => srcset.SrcSetDefinition[];
+	parse: (srcset: string, options?: srcset.SrcSetOptions) => srcset.SrcSetDefinition[];
 
 	/**
 	Stringify `SrcSetDefinition`s.
@@ -60,7 +68,7 @@ declare const srcset: {
 	// banner-HD.jpg 2x, banner-phone.jpg 100w, banner-phone-HD.jpg 100w 2x
 	```
 	*/
-	stringify: (srcSetDefinitions: srcset.SrcSetDefinition[]) => string;
+	stringify: (srcSetDefinitions: srcset.SrcSetDefinition[], options?: srcset.SrcSetOptions) => string;
 };
 
 export = srcset;

--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ const validDescriptorCheck = (value, postfix, descriptor) => {
 	}
 };
 
-exports.parse = (string, {strict = true} = {}) => {
+exports.parse = (string, {strict = false} = {}) => {
 	const allDescriptors = strict ? {} : undefined;
 	return string.split(imageCandidateRegex)
 		.filter((part, index) => index % 2 === 1)
@@ -105,7 +105,7 @@ exports.parse = (string, {strict = true} = {}) => {
 
 const knownDescriptors = new Set(['width', 'height', 'density']);
 
-exports.stringify = (array, {strict = true} = {}) => {
+exports.stringify = (array, {strict = false} = {}) => {
 	const allDescriptors = strict ? {} : null;
 	return array.map(element => {
 		if (!element.url) {

--- a/index.js
+++ b/index.js
@@ -62,8 +62,7 @@ const validDescriptorCheck = (value, postfix, descriptor) => {
 };
 
 exports.parse = (string, {strict = true} = {}) => {
-	const strict = options.strict !== false;
-	const allDescriptors = strict ? new Set() : null;
+	const allDescriptors = strict ? new Set() : undefined;
 	return string.split(imageCandidateRegex)
 		.filter((part, index) => index % 2 === 1)
 		.map(part => {
@@ -101,8 +100,7 @@ exports.parse = (string, {strict = true} = {}) => {
 
 const knownDescriptors = new Set(['width', 'height', 'density']);
 
-exports.stringify = (array, options = {strict: true}) => {
-	const strict = options.strict !== false;
+exports.stringify = (array, {strict = true} = {}) => {
 	const allDescriptors = strict ? new Set() : null;
 	return array.map(element => {
 		if (!element.url) {
@@ -121,7 +119,7 @@ exports.stringify = (array, options = {strict: true}) => {
 
 		const result = [element.url];
 
-		descriptorKeys.forEach(descriptorKey => {
+		for (const descriptorKey of descriptorKeys) {
 			const value = element[descriptorKey];
 			let postfix;
 			if (descriptorKey === 'width') {
@@ -140,7 +138,7 @@ exports.stringify = (array, options = {strict: true}) => {
 			}
 
 			result.push(descriptor);
-		});
+		}
 
 		return result.join(' ');
 	}).join(', ');

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ const duplicateDescriptorCheck = (allDescriptors, descriptor) => {
 	allDescriptors.add(descriptor);
 };
 
-const descriptorCountyCheck = (allDescriptors, currentDescriptors) => {
+const descriptorCountCheck = (allDescriptors, currentDescriptors) => {
 	if (currentDescriptors.length === 0) {
 		duplicateDescriptorCheck(allDescriptors, FALLBACK_DESCRIPTOR);
 	} else if (currentDescriptors.length > 1) {
@@ -73,7 +73,7 @@ exports.parse = (string, {strict = true} = {}) => {
 			const descriptors = elements.length > 0 ? elements : ['1x'];
 
 			if (strict) {
-				descriptorCountyCheck(allDescriptors, elements);
+				descriptorCountCheck(allDescriptors, elements);
 			}
 
 			for (const descriptor of descriptors) {
@@ -114,7 +114,7 @@ exports.stringify = (array, {strict = true} = {}) => {
 		const descriptorKeys = Object.keys(element).filter(key => knownDescriptors.has(key));
 
 		if (strict) {
-			descriptorCountyCheck(allDescriptors, descriptorKeys);
+			descriptorCountCheck(allDescriptors, descriptorKeys);
 		}
 
 		const result = [element.url];

--- a/index.js
+++ b/index.js
@@ -17,57 +17,85 @@ We intentionally implement a loose rule here so that we can perform more aggress
 */
 const imageCandidateRegex = /\s*([^,]\S*[^,](?:\s+[^,]+)?)\s*(?:,|$)/;
 
-function deepUnique(array) {
-	return array.sort().filter((element, index) => {
-		return JSON.stringify(element) !== JSON.stringify(array[index - 1]);
-	});
-}
+const FALLBACK_DESCRIPTOR = '';
 
-exports.parse = string => {
-	return deepUnique(
-		string.split(imageCandidateRegex)
-			.filter((part, index) => index % 2 === 1)
-			.map(part => {
-				const [url, ...elements] = part.trim().split(/\s+/);
+const checkDescriptor = (strict, allDescriptors, descriptor) => {
+	if (!strict) {
+		return;
+	}
 
-				const result = {url};
+	if (allDescriptors.has(descriptor)) {
+		if (descriptor === FALLBACK_DESCRIPTOR) {
+			throw new Error('Only one fallback image is allowed');
+		} else {
+			throw new Error(`No more than one image candidate is allowed for a given descriptor: ${descriptor}`);
+		}
+	}
 
-				const descriptors = elements.length > 0 ? elements : ['1x'];
+	allDescriptors.add(descriptor);
+};
 
-				for (const descriptor of descriptors) {
-					const postfix = descriptor[descriptor.length - 1];
-					const value = Number.parseFloat(descriptor.slice(0, -1));
+exports.parse = (string, options = {strict: true}) => {
+	const strict = options.strict !== false;
+	const allDescriptors = strict ? new Set() : null;
+	return string.split(imageCandidateRegex)
+		.filter((part, index) => index % 2 === 1)
+		.map(part => {
+			const [url, ...elements] = part.trim().split(/\s+/);
 
-					if (Number.isNaN(value)) {
+			const result = {url};
+
+			if (elements.length === 0) {
+				checkDescriptor(strict, allDescriptors, FALLBACK_DESCRIPTOR);
+			}
+
+			const descriptors = elements.length > 0 ? elements : ['1x'];
+
+			if (strict && descriptors.length > 1) {
+				throw new Error(`Image candidate may have no more than one descriptor, found ${descriptors.length}: ${part}`);
+			}
+
+			for (const descriptor of descriptors) {
+				const postfix = descriptor[descriptor.length - 1];
+				const value = Number.parseFloat(descriptor.slice(0, -1));
+
+				checkDescriptor(strict, allDescriptors, descriptor);
+
+				if (Number.isNaN(value)) {
+					if (strict) {
 						throw new TypeError(`${descriptor.slice(0, -1)} is not a valid number`);
-					}
-
-					if (postfix === 'w') {
-						if (value <= 0) {
-							throw new Error('Width descriptor must be greater than zero');
-						} else if (!Number.isInteger(value)) {
-							throw new TypeError('Width descriptor must be an integer');
-						}
-
-						result.width = value;
-					} else if (postfix === 'x') {
-						if (value <= 0) {
-							throw new Error('Pixel density descriptor must be greater than zero');
-						}
-
-						result.density = value;
 					} else {
-						throw new Error(`Invalid srcset descriptor: ${descriptor}`);
-					}
-
-					if (result.width && result.density) {
-						throw new Error('Image candidate string cannot have both width descriptor and pixel density descriptor');
+						continue;
 					}
 				}
 
-				return result;
-			})
-	);
+				if (postfix === 'w') {
+					if (strict && value <= 0) {
+						throw new Error('Width descriptor must be greater than zero');
+					} else if (strict && !Number.isInteger(value)) {
+						throw new TypeError('Width descriptor must be an integer');
+					}
+
+					result.width = value;
+				} else if (postfix === 'h') {
+					if (strict) {
+						throw new Error(`Height descriptor is no longer allowed: ${descriptor}`);
+					}
+
+					result.height = value;
+				} else if (postfix === 'x') {
+					if (strict && value <= 0) {
+						throw new Error('Pixel density descriptor must be greater than zero');
+					}
+
+					result.density = value;
+				} else if (strict) {
+					throw new Error(`Invalid srcset descriptor: ${descriptor}`);
+				}
+			}
+
+			return result;
+		});
 };
 
 exports.stringify = array => {

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ const validDescriptorCheck = (value, postfix, descriptor) => {
 	}
 };
 
-exports.parse = (string, options = {strict: true}) => {
+exports.parse = (string, {strict = true} = {}) => {
 	const strict = options.strict !== false;
 	const allDescriptors = strict ? new Set() : null;
 	return string.split(imageCandidateRegex)

--- a/readme.md
+++ b/readme.md
@@ -58,9 +58,27 @@ banner-HD.jpg 2x, banner-phone.jpg 100w, banner-super-HD.jpg 3x
 
 ### .parse(string, options?)
 
-Accepts a srcset string and returns an array of objects with the possible properties: `url` (always), `width`, `density`.
+Accepts a srcset string and returns an array of objects with the possible properties: `url` (always), `width`, `density`, and `height`.
 
-If options is set to `{strict: false}`, it will attempt to parse invalid input. Otherwise errors are thrown on invalid input.
+In strict mode (default), it will throw on invalid input. Return objects will have either `width` or `density`.
+
+If options is set to `{strict: false}`, it will attempt to parse invalid input and recognize the `height` descriptor. Returned objects may have multiple descriptor fields (e.g. `width` and `density`).
+
+#### string
+
+Type: `string`
+
+srcset string
+
+#### options
+
+Type: `object`
+
+##### strict
+
+Type: `boolean`
+
+Enable or disable strict mode
 
 ### .stringify(array, options?)
 
@@ -68,7 +86,23 @@ Accepts an array of objects with the possible properties: `url` (required), and 
 
 By default it will validate the objects and throw an error if they would produce an invalid srcset string.
 
-If options is set to `{strict: false}`, it will skip validation.
+If options is set to `{strict: false}`, it will skip validation and also allow for a `height` field.
+
+#### array
+
+Type: `array`
+
+An array of objects. Each object should have a `url` field and may have either `width` or `density`.
+
+#### options
+
+Type: `object`
+
+##### strict
+
+Type: `boolean`
+
+Enable or disable strict mode
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -56,9 +56,11 @@ banner-HD.jpg 2x, banner-phone.jpg 100w, banner-super-HD.jpg 3x
 
 ## API
 
-### .parse()
+### .parse(string, [options])
 
 Accepts a srcset string and returns an array of objects with the possible properties: `url` (always), `width`, `density`.
+
+If options is set to `{strict: false}`, it will attempt to parse invalid input. Otherwise errors are thrown on invalid input.
 
 ### .stringify()
 

--- a/readme.md
+++ b/readme.md
@@ -58,17 +58,15 @@ banner-HD.jpg 2x, banner-phone.jpg 100w, banner-super-HD.jpg 3x
 
 ### .parse(string, options?)
 
+Parse the HTML `<img>` [srcset](http://mobile.smashingmagazine.com/2013/08/21/webkit-implements-srcset-and-why-its-a-good-thing/) attribute.
+
 Accepts a srcset string and returns an array of objects with the possible properties: `url` (always), `width`, `density`, and `height`.
-
-In strict mode (default), it will throw on invalid input. Return objects will have either `width` or `density`.
-
-If options is set to `{strict: false}`, it will attempt to parse invalid input and recognize the `height` descriptor. Returned objects may have multiple descriptor fields (e.g. `width` and `density`).
 
 #### string
 
 Type: `string`
 
-srcset string
+A srcset string
 
 #### options
 
@@ -78,21 +76,19 @@ Type: `object`
 
 Type: `boolean`
 
-Enable or disable strict mode
+Default: `true`
 
-### .stringify(array, options?)
+Enable or disable validation of the srcset string. When enabled, an invalid srcset string will cause an error to be thrown. When disabled, a best effort will be made to parse the string, potentially resulting in invalid or nonsensical output.
 
-Accepts an array of objects with the possible properties: `url` (required), and one of `width` or `density` and returns a srcset string.
+### .stringify(SrcSetDefinitions, options?)
 
-By default it will validate the objects and throw an error if they would produce an invalid srcset string.
+Stringify `SrcSetDefinition`s. Accepts an array of `SrcSetDefinition` objects and returns a srcset string.
 
-If options is set to `{strict: false}`, it will skip validation and also allow for a `height` field.
-
-#### array
+#### srcsetDescriptors
 
 Type: `array`
 
-An array of objects. Each object should have a `url` field and may have either `width` or `density`.
+An array of `SrcSetDefinition` objects. Each object should have a `url` field and may have either `width` or `density`. When `options.strict` is set to false, a `height` field is also accepted, and multiple descriptors (`width`, `height`, and`density`) are accepted.
 
 #### options
 
@@ -102,7 +98,9 @@ Type: `object`
 
 Type: `boolean`
 
-Enable or disable strict mode
+Default: `true`
+
+Enable or disable validation of the SrcSetDefinitions. When true, invalid input will cause an error to be thrown. When false, a best effort will be made to stringify invalid input, likely resulting in invalid srcset value.
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,7 @@ banner-HD.jpg 2x, banner-phone.jpg 100w, banner-super-HD.jpg 3x
 
 ## API
 
-### .parse(string, [options])
+### .parse(string, options?)
 
 Accepts a srcset string and returns an array of objects with the possible properties: `url` (always), `width`, `density`.
 

--- a/readme.md
+++ b/readme.md
@@ -62,9 +62,13 @@ Accepts a srcset string and returns an array of objects with the possible proper
 
 If options is set to `{strict: false}`, it will attempt to parse invalid input. Otherwise errors are thrown on invalid input.
 
-### .stringify()
+### .stringify(array, [options])
 
-Accepts an array of objects with the possible properties: `url` (required), `width`, `density` and returns a srcset string.
+Accepts an array of objects with the possible properties: `url` (required), and one of `width` or `density` and returns a srcset string.
+
+By default it will validate the objects and throw an error if they would produce an invalid srcset string.
+
+If options is set to `{strict: false}`, it will skip validation.
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -62,7 +62,7 @@ Accepts a srcset string and returns an array of objects with the possible proper
 
 If options is set to `{strict: false}`, it will attempt to parse invalid input. Otherwise errors are thrown on invalid input.
 
-### .stringify(array, [options])
+### .stringify(array, options?)
 
 Accepts an array of objects with the possible properties: `url` (required), and one of `width` or `density` and returns a srcset string.
 

--- a/readme.md
+++ b/readme.md
@@ -60,7 +60,7 @@ banner-HD.jpg 2x, banner-phone.jpg 100w, banner-super-HD.jpg 3x
 
 Parse the HTML `<img>` [srcset](http://mobile.smashingmagazine.com/2013/08/21/webkit-implements-srcset-and-why-its-a-good-thing/) attribute.
 
-Accepts a srcset string and returns an array of objects with the possible properties: `url` (always), `width`, `density`, and `height`.
+Accepts a srcset string and returns an array of objects with the possible properties: `url` (always), `width`, `height`, and `density`.
 
 #### string
 
@@ -76,7 +76,7 @@ Type: `object`
 
 Type: `boolean`
 
-Default: `true`
+Default: `false`
 
 Enable or disable validation of the srcset string. When enabled, an invalid srcset string will cause an error to be thrown. When disabled, a best effort will be made to parse the string, potentially resulting in invalid or nonsensical output.
 
@@ -88,7 +88,7 @@ Stringify `SrcSetDefinition`s. Accepts an array of `SrcSetDefinition` objects an
 
 Type: `array`
 
-An array of `SrcSetDefinition` objects. Each object should have a `url` field and may have either `width` or `density`. When `options.strict` is set to false, a `height` field is also accepted, and multiple descriptors (`width`, `height`, and`density`) are accepted.
+An array of `SrcSetDefinition` objects. Each object should have a `url` field and may have `width`, `height` or `density` fields. When `options.strict` is set to true, only `width` or `density` is permitted.
 
 #### options
 
@@ -98,7 +98,7 @@ Type: `object`
 
 Type: `boolean`
 
-Default: `true`
+Default: `false`
 
 Enable or disable validation of the SrcSetDefinitions. When true, invalid input will cause an error to be thrown. When false, a best effort will be made to stringify invalid input, likely resulting in invalid srcset value.
 

--- a/test.js
+++ b/test.js
@@ -124,7 +124,8 @@ invalidArrays.forEach(invalidSrcset => {
 
 invalidArrays.forEach(invalidSrcset => {
 	test(`.stringify() should not throw on invalid input when strict mode is disabled: ${JSON.stringify(invalidSrcset)}`, t => {
-		srcset.stringify(invalidSrcset, {strict: false});
-		t.pass();
+		t.notThrows(() => {
+			srcset.stringify(invalidSrcset, {strict: false});
+		});
 	});
 });

--- a/test.js
+++ b/test.js
@@ -87,20 +87,20 @@ const invalidStrings = [
 	'banner.jpeg nonsense' // Nonsense descriptor
 ];
 
-invalidStrings.forEach(invalidSrcset => {
+for (const invalidSrcset of invalidStrings) {
 	test(`.parse() should throw on invalid input when strict mode is enabled: "${invalidSrcset}"`, t => {
 		t.throws(() => {
 			srcset.parse(invalidSrcset, {strict: true});
 		});
 	});
-});
+}
 
-invalidStrings.forEach(invalidSrcset => {
+for (const invalidSrcset of invalidStrings) {
 	test(`.parse() should not throw on invalid input when strict mode is disabled: "${invalidSrcset}"`, t => {
 		srcset.parse(invalidSrcset, {strict: false});
 		t.pass();
 	});
-});
+}
 
 const invalidArrays = [
 	[{url: 'banner.jpeg'}, {url: 'fallback.jpeg'}], // Multiple fallback images
@@ -114,18 +114,18 @@ const invalidArrays = [
 	[{url: 'banner.jpeg', width: 'nonsense'}] // Nonsense descriptor
 ];
 
-invalidArrays.forEach(invalidSrcset => {
+for (const invalidSrcset of invalidArrays) {
 	test(`.stringify() should throw on invalid input when strict mode is enabled: ${JSON.stringify(invalidSrcset)}`, t => {
 		t.throws(() => {
 			srcset.stringify(invalidSrcset, {strict: true});
 		});
 	});
-});
+}
 
-invalidArrays.forEach(invalidSrcset => {
+for (const invalidSrcset of invalidArrays) {
 	test(`.stringify() should not throw on invalid input when strict mode is disabled: ${JSON.stringify(invalidSrcset)}`, t => {
 		t.notThrows(() => {
 			srcset.stringify(invalidSrcset, {strict: false});
 		});
 	});
-});
+}

--- a/test.js
+++ b/test.js
@@ -2,7 +2,7 @@ import test from 'ava';
 import srcset from '.';
 
 test('.parse() should parse srcset', t => {
-	const fixture = '  banner-HD.jpeg 2x,   banner-HD.jpeg 2x,  banner-HD.jpeg 2x,    banner-phone.jpeg   100w, http://site.com/image.jpg?foo=bar,lorem 3x ,banner.jpeg    ';
+	const fixture = ' banner-HD.jpeg 2x,    banner-phone.jpeg   100w, http://site.com/image.jpg?foo=bar,lorem 3x ,banner.jpeg    ';
 
 	t.deepEqual(srcset.parse(fixture), [
 		{url: 'banner-HD.jpeg', density: 2},
@@ -54,7 +54,7 @@ test('.parse() should not parse invalid srcset', t => {
 });
 
 test('.parse() should parse srcset separated without whitespaces', t => {
-	const fixture = 'banner-HD.jpeg 2x,banner-HD.jpeg 2x,banner-HD.jpeg 2x,banner-phone.jpeg 100w,http://site.com/image.jpg?foo=100w,lorem 1x';
+	const fixture = 'banner-HD.jpeg 2x,banner-phone.jpeg 100w,http://site.com/image.jpg?foo=100w,lorem 1x';
 
 	t.deepEqual(srcset.parse(fixture), [
 		{url: 'banner-HD.jpeg', density: 2},
@@ -74,4 +74,31 @@ test('.stringify() should stringify srcset', t => {
 		srcset.stringify(fixture),
 		'banner-HD.jpeg 2x, banner-phone.jpeg 100w'
 	);
+});
+
+const invalidSrcsets = [
+	'banner.jpeg, fallback.jpeg', // Multiple fallback images
+	'banner-phone-HD.jpg 100w 2x', // Multiple descriptors
+	'banner-HD.jpeg 2x, banner.jpeg 2x', // Multiple images with the same descriptor
+	'banner-phone.jpeg 100h', // Height attribute
+	'banner-phone.jpeg 100.1w', // Non-integer width
+	'banner-phone.jpeg -100w', // Negative width
+	'banner-hd.jpeg -2x', // Negative density
+	'banner.jpeg 3q', // Invalid descriptor
+	'banner.jpeg nonsense' // Nonsense descriptor
+];
+
+invalidSrcsets.forEach(invalidSrcset => {
+	test(`.parse() should throw on invalid input when strict mode is enabled: "${invalidSrcset}"`, t => {
+		t.throws(() => {
+			srcset.parse(invalidSrcset, {strict: true});
+		});
+	});
+});
+
+invalidSrcsets.forEach(invalidSrcset => {
+	test(`.parse() should not throw on invalid input when strict mode is disabled: "${invalidSrcset}`, t => {
+		srcset.parse(invalidSrcset, {strict: false});
+		t.pass();
+	});
 });

--- a/test.js
+++ b/test.js
@@ -31,28 +31,6 @@ test('.parse() should parse URLs with commas', t => {
 	]);
 });
 
-test('.parse() should not parse invalid srcset', t => {
-	t.throws(() => {
-		srcset.parse('banner-phone-HD.jpeg 100w 2x');
-	});
-
-	t.throws(() => {
-		srcset.parse('banner-phone-HD.jpeg -100w');
-	});
-
-	t.throws(() => {
-		srcset.parse('banner-phone-HD.jpeg -2x');
-	});
-
-	t.throws(() => {
-		srcset.parse('banner-phone-HD.jpeg 100.5w');
-	});
-
-	t.throws(() => {
-		srcset.parse('banner-phone-HD.jpeg xxx');
-	});
-});
-
 test('.parse() should parse srcset separated without whitespaces', t => {
 	const fixture = 'banner-HD.jpeg 2x,banner-phone.jpeg 100w,http://site.com/image.jpg?foo=100w,lorem 1x';
 
@@ -84,7 +62,7 @@ const invalidStrings = [
 	'banner-phone.jpeg -100w', // Negative width
 	'banner-hd.jpeg -2x', // Negative density
 	'banner.jpeg 3q', // Invalid descriptor
-	'banner.jpeg nonsense', // Nonsense descriptor
+	'banner.jpeg xxx', // Nonsense descriptor
 	'banner.jpg 1x, fallback.jpg', // Duplicate descriptor because the fallback is equivalent to 1x
 	'banner.jpg 2x, other.jpg 2.0x' // Duplicate descriptors after normalizing
 ];
@@ -113,7 +91,7 @@ const invalidArrays = [
 	[{url: 'banner-phone.jpeg', width: -100}], // Negative width
 	[{url: 'banner-hd.jpeg', density: -2}], // Negative density
 	[{url: 'banner.jpeg', width: Number.NaN}], // Invalid descriptor
-	[{url: 'banner.jpeg', width: 'nonsense'}], // Nonsense descriptor
+	[{url: 'banner.jpeg', width: 'xxx'}], // Nonsense descriptor
 	[{url: 'banner.jpg', density: 1}, {url: 'fallback.jpg'}], // Duplicate descriptor because the fallback is equivalent to 1x
 	[{url: 'banner-hd.jpg', density: 2}, {url: 'other-hd.jpg', density: 2}] // Duplicate descriptors after normalizing
 ];

--- a/test.js
+++ b/test.js
@@ -66,7 +66,6 @@ test('.parse() should parse srcset separated without whitespaces', t => {
 test('.stringify() should stringify srcset', t => {
 	const fixture = [
 		{url: 'banner-HD.jpeg', density: 2},
-		{url: 'banner-HD.jpeg', density: 2},
 		{url: 'banner-phone.jpeg', width: 100}
 	];
 
@@ -76,11 +75,11 @@ test('.stringify() should stringify srcset', t => {
 	);
 });
 
-const invalidSrcsets = [
+const invalidStrings = [
 	'banner.jpeg, fallback.jpeg', // Multiple fallback images
 	'banner-phone-HD.jpg 100w 2x', // Multiple descriptors
 	'banner-HD.jpeg 2x, banner.jpeg 2x', // Multiple images with the same descriptor
-	'banner-phone.jpeg 100h', // Height attribute
+	'banner-phone.jpeg 100h', // Height descriptor
 	'banner-phone.jpeg 100.1w', // Non-integer width
 	'banner-phone.jpeg -100w', // Negative width
 	'banner-hd.jpeg -2x', // Negative density
@@ -88,7 +87,7 @@ const invalidSrcsets = [
 	'banner.jpeg nonsense' // Nonsense descriptor
 ];
 
-invalidSrcsets.forEach(invalidSrcset => {
+invalidStrings.forEach(invalidSrcset => {
 	test(`.parse() should throw on invalid input when strict mode is enabled: "${invalidSrcset}"`, t => {
 		t.throws(() => {
 			srcset.parse(invalidSrcset, {strict: true});
@@ -96,9 +95,36 @@ invalidSrcsets.forEach(invalidSrcset => {
 	});
 });
 
-invalidSrcsets.forEach(invalidSrcset => {
-	test(`.parse() should not throw on invalid input when strict mode is disabled: "${invalidSrcset}`, t => {
+invalidStrings.forEach(invalidSrcset => {
+	test(`.parse() should not throw on invalid input when strict mode is disabled: "${invalidSrcset}"`, t => {
 		srcset.parse(invalidSrcset, {strict: false});
+		t.pass();
+	});
+});
+
+const invalidArrays = [
+	[{url: 'banner.jpeg'}, {url: 'fallback.jpeg'}], // Multiple fallback images
+	[{url: 'banner-phone-HD.jpg', width: 100, density: 2}], // Multiple descriptors
+	[{url: 'banner-HD.jpeg', density: 2}, {url: 'banner.jpeg', density: 2}], // Multiple images with the same descriptor
+	[{url: 'banner-phone.jpeg', height: 100}], // Height descriptor
+	[{url: 'banner-phone.jpeg', width: 100.1}], // Non-integer width
+	[{url: 'banner-phone.jpeg', width: -100}], // Negative width
+	[{url: 'banner-hd.jpeg', density: -2}], // Negative density
+	[{url: 'banner.jpeg', width: Number.NaN}], // Invalid descriptor
+	[{url: 'banner.jpeg', width: 'nonsense'}] // Nonsense descriptor
+];
+
+invalidArrays.forEach(invalidSrcset => {
+	test(`.stringify() should throw on invalid input when strict mode is enabled: ${JSON.stringify(invalidSrcset)}`, t => {
+		t.throws(() => {
+			srcset.stringify(invalidSrcset, {strict: true});
+		});
+	});
+});
+
+invalidArrays.forEach(invalidSrcset => {
+	test(`.stringify() should not throw on invalid input when strict mode is disabled: ${JSON.stringify(invalidSrcset)}`, t => {
+		srcset.stringify(invalidSrcset, {strict: false});
 		t.pass();
 	});
 });


### PR DESCRIPTION
There's a lot going on here, but I think it all makes sense and fits together:

The headline feature is that `.parse()` and `.stringify()` both now accept an optional second argument for options. The only current option is `strict` which defaults to ~`true`~ Update: now `false`.
  * ~~This might be considered a breaking change for `.stringify()` since it previously worked in "loose mode". I suppose we could change the default to `false` there if you prefer.~~
  * Update: this could now be considered a breaking change for `.parse()`

I also added several additional checks when strict mode is enabled:
  * no more than one image candidate for any given descriptor
  * no more than one descriptor per image candidate 
    * Note: This check was sort of already there - you couldn't do two *different* descriptors, e.g. `100w 2x`, but it would allow two of the same, e.g. `100w 200w`.
  * height descriptor gets an explicit error message (or is silently accepted when strict mode is disabled)

Because of the duplicate check in strict-mode, I removed the `deepUnique` function that was used in `.parse()` and the `Set` that was used in `.stringify()`. In non-strict-mode, it makes sense to allow duplicates IMO.

Finally, I tweaked a few of the existing tests to ensure they passed in strict mode, and then added a handful of invalid fixtures and tests to ensure they throw in strict mode but not in non-strict-mode.

~One thing I haven't dug into yet is equating the fallback image (with no descriptor) to `1x` - right now the validator treates those as two different things and therfore allows something like `a.jpg 1x, b.jpg` to pass. It also considers `1x` and `1.0x` to be different. So there's room for further improvement, but I still think this is a step in the right direction.~ Update: this is now included in this PR via https://github.com/nfriedly/srcset/pull/1
